### PR TITLE
add external link icon to companion guide link nav

### DIFF
--- a/apps/ite-portal/src/app/portal/portal.component.html
+++ b/apps/ite-portal/src/app/portal/portal.component.html
@@ -140,8 +140,9 @@
               target="__blank"
               rel="noopener noreferrer"
               type="application/pdf"
-              >Companion Guide (PDF)</a
-            >
+              class="external-link"
+              >Companion Guide (PDF)
+            </a>
           </li>
         </ul>
       </div>

--- a/apps/ite-portal/src/index.html
+++ b/apps/ite-portal/src/index.html
@@ -9,6 +9,10 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />

--- a/apps/ite-portal/src/styles.scss
+++ b/apps/ite-portal/src/styles.scss
@@ -9,7 +9,7 @@ a.external-link {
   &::after {
     content: '\e89e';
     position: absolute;
-    left: 100%;
+    left: calc(100% + 6px);
     font-family: 'Material Symbols Outlined';
   }
 }

--- a/apps/ite-portal/src/styles.scss
+++ b/apps/ite-portal/src/styles.scss
@@ -2,3 +2,14 @@
 .ngx-tableau-viz {
   height: calc(100vh - 3rem) !important;
 }
+
+a.external-link {
+  position: relative;
+
+  &::after {
+    content: '\e89e';
+    position: absolute;
+    left: 100%;
+    font-family: 'Material Symbols Outlined';
+  }
+}


### PR DESCRIPTION
- This PR adds a new utility class `.external-link` to add an "external resource icon" to any a element with that class.
- adds external link icon to the Companion Guide (PDF) link in the nav menu


> https://www.pivotaltracker.com/n/projects/2581014/stories/185130059