### PR TITLE
add trim function to csv headers

### DIFF
--- a/libs/bhsd/submit-new-file-feature/src/lib/submit-extract/submit-extract.component.ts
+++ b/libs/bhsd/submit-new-file-feature/src/lib/submit-extract/submit-extract.component.ts
@@ -179,6 +179,9 @@ export class SubmitExtractComponent implements OnInit {
           const recordData: ExtractRecordData[] = this.papa.parse(csvText, {
             header: true,
             skipEmptyLines: true,
+            transformHeader:function(h) {
+              return h.trim();
+            },
             complete: (results) => results.data,
           }).data;
 


### PR DESCRIPTION
While testing a backend ticket, Ann asked about the possibility of field names with white space in them. this PR preempts that on the backend by trimming the fields when they're parsed.