### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ npm run start:api
 To start the UI, run the following command from the root of the `ite-portal` directory:
 
 ```bash
-nx serve provider-gateway
+npx nx serve provider-gateway
 ```
 
 or
 
 ```bash
-nx serve ite-portal
+npx nx serve ite-portal
 ```
 
 ### Initial Local API Setup


### PR DESCRIPTION
changes the command to start an nx project in case the user does not have nx installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the start commands in the README for improved clarity and accuracy. Users should now use `npx` to invoke `nx` to serve the `provider-gateway` and `ite-portal`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->